### PR TITLE
refactor(1392): replace teacher with staff

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/common/data/domain/model/enums/EUserCategory.java
+++ b/src/main/java/fr/avenirsesr/portfolio/common/data/domain/model/enums/EUserCategory.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum EUserCategory {
-  TEACHER,
+  STAFF,
   STUDENT,
   ;
 }

--- a/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
+++ b/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
@@ -19,7 +19,7 @@ public enum EErrorCode {
   TRACE_NOT_FOUND("Trace not found"),
   AMS_NOT_FOUND("AMS not found"),
   USER_IS_NOT_STUDENT_EXCEPTION("User is not student"),
-  USER_IS_NOT_TEACHER_EXCEPTION("User is not teacher"),
+  USER_IS_NOT_STAFF_EXCEPTION("User is not staff"),
   LANGUAGE_NOT_SUPPORTED("Language not supported"),
   INVALID_ARGUMENT_TYPE("The type of the argument is invalid"),
   DECLARED_SKILL_NOT_AVAILABLE("Declared skill not available"),


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR renames the `TEACHER` terminology to `STAFF` in the shared common library, aligning the domain model with the updated naming convention.

**Main changes:**
- ♻️ Renames `EUserCategory.TEACHER` → `EUserCategory.STAFF` in the user category enum
- ♻️ Renames `USER_IS_NOT_TEACHER_EXCEPTION` → `USER_IS_NOT_STAFF_EXCEPTION` in the error code enum

---

### Reference to an Issue, Feature, Task, User Story or another PR
Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1392

---

### Documentation
No documentation changes required — this is a pure enum value rename in the common library.

**Modified files:**
- `src/main/java/fr/avenirsesr/portfolio/common/data/domain/model/enums/EUserCategory.java` — rename `TEACHER` to `STAFF`
- `src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java` — rename `USER_IS_NOT_TEACHER_EXCEPTION` to `USER_IS_NOT_STAFF_EXCEPTION`

---

### Target Branch
`develop`

---

### Additional Notes
This is a foundational change in the shared `avenirs-portfolio-common` library. Dependent modules (`avenirs-portfolio-api`) must also update their references to `EUserCategory.STAFF` and `EErrorCode.USER_IS_NOT_STAFF_EXCEPTION` in a companion PR.

The rename is purely terminological — no behavioural changes are introduced.

---

### Known Limitations or Side Effects
Downstream modules referencing `EUserCategory.TEACHER` or `USER_IS_NOT_TEACHER_EXCEPTION` will fail to compile until they are updated to use the new enum values.

---

## ✅ Checklist

- [ ] a11y tested (backend library, not applicable)
- [x] Tests provided (no test changes needed — enum rename only)
- [ ] i18n handled (backend library, not applicable)
- [ ] Performance tests (no performance impact)
- [x] No unnecessary code (clean rename, no leftover references)
- [x] Code style and formatting rules respected (conventions respected)
- [x] Semantic Versioning respected (conventional commit used)
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)