### PR TITLE
feat(1403): Errors - add REFLECTION_TOO_LONG error code

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
+++ b/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
@@ -31,6 +31,7 @@ public enum EErrorCode {
   CONFIGURATION_ERROR("Configuration error"),
   TITLE_TOO_LONG("The length of the title is too long"),
   DESCRIPTION_TOO_LONG("The length of the description is too long"),
+  REFLECTION_TOO_LONG("The length of the reflection is too long"),
   RATING_OUT_OF_BOUNCE("Rating is out of bounce"),
   ASSOCIATION_NOT_FOUND("Association not found"),
   SELF_KNOWLEDGE_ELEMENT_NOT_FOUND("Self knowledge element not found"),


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR adds the `REFLECTION_TOO_LONG` error code to the shared `EErrorCode` enum in `avenirs-portfolio-common`, supporting the renaming of the `description` field to `reflection` in the `DeclaredSkill` domain.

**Main changes:**
- ✨ Adds `REFLECTION_TOO_LONG` error code to `EErrorCode` enum

---

### Reference to an Issue, Feature, Task, User Story or another PR
Linked to https://github.com/avenirs-esr/AVENIRS-Project/issues/1403

---

### Documentation
No additional documentation required — additive enum change in the common library.

**Modified files:**
- `src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java` — add `REFLECTION_TOO_LONG("The length of the reflection is too long")`

---

### Target Branch
`develop`

---

### Additional Notes
This is a foundational change in the shared `avenirs-portfolio-common` library. The dependent `avenirs-portfolio-api` module will use this new error code when validating the length of the `reflection` field on `DeclaredSkill`.

The change is purely additive — no existing error codes are modified.

---

### Known Limitations or Side Effects
No known limitations or side effects.

---

## ✅ Checklist

- [ ] a11y tested (backend library, not applicable)
- [x] Tests provided (no test changes needed — additive enum value only)
- [ ] i18n handled (backend library, not applicable)
- [ ] Performance tests (no performance impact)
- [x] No unnecessary code (clean addition, no leftover references)
- [x] Code style and formatting rules respected (conventions respected)
- [x] Semantic Versioning respected (conventional commit used)
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)