### PR TITLE
Revert "feat(1403): Errors - add REFLECTION_TOO_LONG error code"

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
+++ b/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
@@ -31,7 +31,6 @@ public enum EErrorCode {
   CONFIGURATION_ERROR("Configuration error"),
   TITLE_TOO_LONG("The length of the title is too long"),
   DESCRIPTION_TOO_LONG("The length of the description is too long"),
-  REFLECTION_TOO_LONG("The length of the reflection is too long"),
   RATING_OUT_OF_BOUNCE("Rating is out of bounce"),
   ASSOCIATION_NOT_FOUND("Association not found"),
   SELF_KNOWLEDGE_ELEMENT_NOT_FOUND("Self knowledge element not found"),


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
This PR reverts the `REFLECTION_TOO_LONG` error code addition that was introduced in a previous commit, removing it from the `EErrorCode` enum.

**Main changes:**
- 🔥 Removes `REFLECTION_TOO_LONG` error code from `EErrorCode` enum (reverts feat(1403))

---

### Reference to an Issue, Feature, Task, User Story or another PR
Relates to https://github.com/avenirs-esr/AVENIRS-Project/issues/1403

Reverts avenirs-esr/avenirs-portfolio-common#50

---

### Documentation
No documentation changes required.

**Modified files:**
- `src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java` — remove `REFLECTION_TOO_LONG` entry

---

### Target Branch
`develop`

---

### Additional Notes
This revert was necessary to clean up the `develop` branch state. The `REFLECTION_TOO_LONG` error code will be re-introduced as part of a clean branch for issue #1403.

---

### Known Limitations or Side Effects
Any module depending on `EErrorCode.REFLECTION_TOO_LONG` will fail to compile until the error code is re-introduced.

---

## ✅ Checklist

- [ ] a11y tested (backend library, not applicable)
- [x] Tests provided (no test changes needed — revert of enum value only)
- [ ] i18n handled (backend library, not applicable)
- [ ] Performance tests (no performance impact)
- [x] No unnecessary code (clean revert)
- [x] Code style and formatting rules respected (conventions respected)
- [x] Semantic Versioning respected
- [x] Add to `CHANGELOG.md` file all properties and database change and details for the update process (no database or property changes)