### PR TITLE
feat(1346): enforce trace type constraints and link character limit

### DIFF
--- a/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
+++ b/src/main/java/fr/avenirsesr/portfolio/common/error/domain/model/enums/EErrorCode.java
@@ -17,6 +17,7 @@ public enum EErrorCode {
   SKILL_NOT_FOUND("Skill not found"),
   SKILL_LEVEL_NOT_FOUND("Skill level not found"),
   TRACE_NOT_FOUND("Trace not found"),
+  INVALID_TRACE_TYPE("Invalid trace type"),
   AMS_NOT_FOUND("AMS not found"),
   USER_IS_NOT_STUDENT_EXCEPTION("User is not student"),
   USER_IS_NOT_STAFF_EXCEPTION("User is not staff"),

--- a/src/main/java/fr/avenirsesr/portfolio/common/validation/domain/constraints/FieldMaxLengths.java
+++ b/src/main/java/fr/avenirsesr/portfolio/common/validation/domain/constraints/FieldMaxLengths.java
@@ -17,6 +17,7 @@ public final class FieldMaxLengths {
   public static final int BIO_LENGTH = 400;
   public static final int AI_JUSTIFICATION_LENGTH = 200;
   public static final int PERSONAL_NOTE_LENGTH = 200;
+  public static final int LINK_LENGTH = 2000;
   public static final int RATING_MIN = 1;
   public static final int RATING_MAX = 5;
   public static final int ACTIVITY_EXECUTION_PERIOD_INFO = 200;


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
- New error code _`INVALID_TRACE_TYPE`_ for invalid trace type operations: Introduced a dedicated error code returned when an action is incompatible with the current trace type (e.g. attempting to attach a file to a trace that already has a link)
- Character limit enforced on trace link URLs: Defined a maximum character length for trace link URLs

---

### Reference to an Issue, Feature, Task, User Story or another PR
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1346
- Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/1452
- Required for PR https://github.com/avenirs-esr/avenirs-portfolio-api/pull/274

---

### Target Branch
develop

---

### Additional Notes
- The error code is intentionally generic to leave room for a future _`type`_ field on traces

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [x] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [x] No unnecessary code (e.g., debug logs, commented code)
- [x] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and detaiils for the update process